### PR TITLE
add dotenv to config.py

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,4 +1,7 @@
 from pydantic import BaseSettings
+from dotenv import load_dotenv
+
+load_dotenv('.evn')
 
 
 class Settings(BaseSettings):


### PR DESCRIPTION
I changed config.py in app , This change is add dotenv for load ".env" file in config.py 
app => config.py
from dotenv import load_dotenv 

load_dotenv(".env") 

When I made the ".env" file based on your training, I encountered an error after running the project . I found out with Key Search that I should use this command to call the  ".env" file