### PR TITLE
Update oauth2.py

### DIFF
--- a/app/oauth2.py
+++ b/app/oauth2.py
@@ -49,6 +49,8 @@ def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(
 
     token = verify_access_token(token, credentials_exception)
 
-    user = db.query(models.User).filter(models.User.id == token.id).first()
+    user = db.query(models.User.id, models.User.email, models.User.created_at)\
+        .filter(models.User.id == token.id)\
+        .first()
 
     return user


### PR DESCRIPTION
get_current_user is mostly used for maintaining sessions. Excluding password in order to ensure password attribute is not accessible in the routes that depend on get_current_user