### PR TITLE
changes in update_post PUT request to exclude fields not set in payload

### DIFF
--- a/app/routers/post.py
+++ b/app/routers/post.py
@@ -95,7 +95,7 @@ def delete_post(id: int, db: Session = Depends(get_db), current_user: int = Depe
 
 
 @router.put("/{id}", response_model=schemas.Post)
-def update_post(id: int, updated_post: schemas.PostCreate, db: Session = Depends(get_db), current_user: int = Depends(oauth2.get_current_user)):
+def update_post(id: int, updated_post: schemas.PostUpdate, db: Session = Depends(get_db), current_user: int = Depends(oauth2.get_current_user)):
 
     # cursor.execute("""UPDATE posts SET title = %s, content = %s, published = %s WHERE id = %s RETURNING *""",
     #                (post.title, post.content, post.published, str(id)))
@@ -114,8 +114,11 @@ def update_post(id: int, updated_post: schemas.PostCreate, db: Session = Depends
     if post.owner_id != current_user.id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN,
                             detail="Not authorized to perform requested action")
+    
+    # Convert Pydantic model to dictionary with exclude_unset=True
+    update_data = updated_post.dict(exclude_unset=True)  # Exclude fields not set in the request
 
-    post_query.update(updated_post.dict(), synchronize_session=False)
+    post_query.update(update_data, synchronize_session=False)
 
     db.commit()
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -14,6 +14,9 @@ class PostBase(BaseModel):
 class PostCreate(PostBase):
     pass
 
+class PostUpdate(PostBase):
+    title: Optional[str]=None
+    content: Optional[str]=None
 
 class UserOut(BaseModel):
     id: int


### PR DESCRIPTION
It will handle the PUT request for update post better
- It will not update the fields which are not set in request payload and retain existing data
- For example, if I want to change only content and not the title, I can set only **content** data, **title** will remain unchanged.