### PR TITLE
Fix user conflict in user

### DIFF
--- a/app/routers/user.py
+++ b/app/routers/user.py
@@ -15,6 +15,10 @@ router = APIRouter(
 @router.post("/", status_code=status.HTTP_201_CREATED, response_model=schemas.UserOut)
 def create_user(user: schemas.UserCreate, db: Session = Depends(get_db)):
 
+    if not db.query(models.User).filter(models.User.email == user.email).first() is None:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT,
+                            detail=f"Username already exists.")
+    
     # hash the password - user.password
     hashed_password = utils.hash(user.password)
     user.password = hashed_password

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -47,3 +47,9 @@ def test_incorrect_login(test_user, client, email, password, status_code):
 
     assert res.status_code == status_code
     # assert res.json().get('detail') == 'Invalid Credentials'
+
+def test_user_conflict_user_already_exists(client, test_user):
+    res = client.post("/users/",
+                      json={"email": test_user["email"], "password": "somePassword"})
+    
+    assert res.status_code == 409


### PR DESCRIPTION
Fixed a small bug, when creating a user that already exists in the database, we get an internal server error. Made some changes in user.py to raise HTTPExpection status code 409, if the user already exists.

Also added a test in test_users.py for status code if the user already exists.