### PR TITLE
Changed dir type in Vote schema

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel, EmailStr
 from datetime import datetime
 from typing import Optional
+from typing import Literal
 
 from pydantic.types import conint
 
@@ -63,4 +64,4 @@ class TokenData(BaseModel):
 
 class Vote(BaseModel):
     post_id: int
-    dir: conint(le=1)
+    dir: Literal[0, 1]


### PR DESCRIPTION
I found that using **Literal[0, 1]** is better type checking by pydantic for the dir type, here's an example error returned from pydantic: 
```
{
	"detail": [
		{
			"type": "literal_error",
			"loc": [
				"body",
				"direction"
			],
			"msg": "Input should be 0 or 1",
			"input": 20,
			"ctx": {
				"expected": "0 or 1"
			}
		}
	]
}
```